### PR TITLE
Add FlowStorm alias to deps.edn

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -19,5 +19,17 @@
                                       cider/piggieback {:mvn/version "0.5.2"}}
                          :extra-paths ["src"
                                        "test"]
-                         :main-opts ["-m" "shadow.cljs.devtools.cli"]}}
+                         :main-opts ["-m" "shadow.cljs.devtools.cli"]}
+
+           ;; This can be a global alias inside ~/.clojure/deps.edn, doesn't contain anything specific
+           ;; to this project
+           :storm {:classpath-overrides {org.clojure/clojure nil}
+                   :extra-deps {com.github.flow-storm/clojure {:mvn/version "1.11.3"}
+                                com.github.flow-storm/flow-storm-dbg {:mvn/version "3.15.5"}}
+                   :jvm-opts ["-Dclojure.storm.instrumentEnable=true"
+                              "-Dclojure.storm.instrumentAutoPrefixes=true"
+                              ;; this will work if you have started your emacs server with M-x server-start
+                              "-Dflowstorm.jarEditorCommand=emacsclient -n +<<LINE>>:0 <<JAR>>/<<FILE>>"
+                              "-Dflowstorm.fileEditorCommand=emacsclient -n +<<LINE>>:0 <<FILE>>"]}
+           }
  :mvn/repos {"github" {:url "https://maven.pkg.github.com/janetacarr/prefix-tree-cljc"}}}


### PR DESCRIPTION
Hi Janet! I'm everywhere haha! 

Adding here a new alias in case you eventually want to try FlowStorm for your projects. This doesn't even need to be on your project, you can add the alias on your ~/.clojure/deps.edn globally so you have it for all your projects.

You add it to your repl sessions by adding the `:storm` alias to any other aliases you already use. And that is it. Whenever you need the debugger UI just evaluate the `:dbg` keyword on your repl, doesn't matter the namespace.

It also includes a small interactive tutorial (~15min) if you click on Help->Tutorial inside the UI.

I hope that helps!
Cheers!